### PR TITLE
Fix GNOME/GTK integration and update libraries

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -93,6 +93,7 @@ parts:
       snapcraftctl set-version "$(git describe --tags)"
     configflags:
       - -DCMAKE_INSTALL_PREFIX:PATH=/usr
+      - -DUPDATE_TRANSLATIONS=ON
     source: https://github.com/mgba-emu/mgba.git
     build-packages:
       - libedit-dev
@@ -113,6 +114,7 @@ parts:
       - qtmultimedia5-dev
       - qttools5-dev
       - qttools5-dev-tools
+      - qttranslations5-l10n
       - libpixman-1-dev
       - libqt5opengl5-dev
       - qtbase5-dev
@@ -121,6 +123,7 @@ parts:
       - librtmp1
       - libqt5multimedia5
       - libqt5multimedia5-plugins
+      - libqt5qml5
       - libelf1
       - libepoxy0
       - libzvbi0
@@ -163,6 +166,7 @@ parts:
       - libavformat57
       - libmagickcore-6.q16-3
       - qt5-style-plugins
+      - qttranslations5-l10n
 
   desktop-qt5:
     build-packages:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -56,6 +56,7 @@ apps:
       - audio-playback
       - opengl
       - joystick
+      - network
   mgba:
     environment:
       XLOCALEDIR: '$SNAP/usr/share/X11/locale'
@@ -72,6 +73,7 @@ apps:
       - audio-playback
       - opengl
       - joystick
+      - network
 
 parts:
   mgba:
@@ -104,6 +106,7 @@ parts:
       - libedit-dev
       - libelf-dev
       - libepoxy-dev
+      - libgail-dev
       - libmagickwand-dev
       - libminizip-dev
       - libpixman-1-dev
@@ -121,6 +124,7 @@ parts:
       - qttranslations5-l10n
       - zlib1g-dev
     stage-packages:
+      - libatk-adaptor
       - libavfilter6
       - libavformat57
       - libavresample3
@@ -130,6 +134,7 @@ parts:
       - libelf1
       - libepoxy0
       - libfftw3-double3
+      - libgail-common
       - libgme0
       - libgomp1
       - libgsm1

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,13 +1,13 @@
 name: mgba
+base: core18
+license: MPL-2.0
+adopt-info: mgba
 summary: mGBA Game Boy Advance Emulator https://mgba.io/
 description: |
   mGBA is an emulator for running Game Boy Advance games. It aims to be faster
   and more accurate than many existing Game Boy Advance emulators, as well as
   adding features that other emulators lack. It also supports Game Boy and
   Game Boy Color games.
-adopt-info: mgba
-base: core18
-license: MPL-2.0
 
 architectures:
   - build-on: i386

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,6 +7,7 @@ description: |
   Game Boy Color games.
 adopt-info: mgba
 base: core18
+license: MPL-2.0
 
 architectures:
   - build-on: i386

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -87,6 +87,7 @@ parts:
       - libswscale-dev
       - qtdeclarative5-dev
       - qtmultimedia5-dev
+      - qttools5-dev
       - qttools5-dev-tools
       - libpixman-1-dev
       - libqt5opengl5-dev

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -15,17 +15,39 @@ architectures:
 confinement: strict
 grade: stable
 
+plugs: # additional plugs to pick up the GTK theme and icons from the system
+  icon-themes:
+    interface: content
+    target: $SNAP/data-dir/icons
+    default-provider: gtk-common-themes
+  sound-themes:
+    interface: content
+    target: $SNAP/data-dir/sounds
+    default-provider: gtk-common-themes
+  gtk-2-engines:
+    interface: content
+    target: $SNAP/lib/gtk-2.0
+    default-provider: gtk2-common-themes:gtk-2-engines
+  gtk-2-themes:
+    interface: content
+    target: $SNAP/share/themes
+    default-provider: gtk2-common-themes:gtk-2-themes
+
 apps:
   mgba-qt:
     environment:
       XLOCALEDIR: '$SNAP/usr/share/X11/locale'
       LOCPATH: '$SNAP/usr/lib/locale'
+      GTK_PATH: $SNAP/lib/gtk-2.0
+      GTK_DATA_PREFIX: $SNAP
+      XDG_DATA_DIRS: $SNAP/share:$XDG_DATA_DIRS
       XDG_CONFIG_HOME: '$HOME/.config'
       XKB_CONFIG_ROOT: '$SNAP/usr/share/X11/xkb'
       XDG_CONFIG_DIRS: '$SNAP/etc/xdg:$XDG_CONFIG_DIRS'
       XDG_DATA_HOME: '$SNAP/usr/share'
       DISABLE_WAYLAND: '1'
       LD_LIBRARY_PATH: '$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/pulseaudio:$LD_LIBRARY_PATH'
+      QT_QPA_PLATFORMTHEME: gtk2 # set default theme to gtk to integrate with system theme (GTK2)
     command: desktop-launch mgba-qt
     plugs:
       - x11

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -96,77 +96,77 @@ parts:
       - -DUPDATE_TRANSLATIONS=ON
     source: https://github.com/mgba-emu/mgba.git
     build-packages:
-      - libedit-dev
-      - libelf-dev
       - libavcodec-dev
+      - libavfilter-dev
       - libavformat-dev
       - libavresample-dev
       - libavutil-dev
-      - libavfilter-dev
-      - libminizip-dev
-      - libpng-dev
-      - libzip-dev
-      - libmagickwand-dev
+      - libedit-dev
+      - libelf-dev
       - libepoxy-dev
-      - libsqlite3-dev
+      - libmagickwand-dev
+      - libminizip-dev
+      - libpixman-1-dev
+      - libpng-dev
+      - libqt5opengl5-dev
       - libsdl2-dev
+      - libsqlite3-dev
       - libswscale-dev
+      - libzip-dev
+      - qtbase5-dev
       - qtdeclarative5-dev
       - qtmultimedia5-dev
       - qttools5-dev
       - qttools5-dev-tools
       - qttranslations5-l10n
-      - libpixman-1-dev
-      - libqt5opengl5-dev
-      - qtbase5-dev
       - zlib1g-dev
     stage-packages:
-      - librtmp1
+      - libavfilter6
+      - libavformat57
+      - libavresample3
+      - libavutil55
+      - libbluray2
+      - libcrystalhd3
+      - libelf1
+      - libepoxy0
+      - libfftw3-double3
+      - libgme0
+      - libgomp1
+      - libgsm1
+      - liblqr-1-0
+      - libltdl7
+      - libmagickcore-6.q16-3
+      - libmagickwand-6.q16-3
+      - libmodplug1
+      - libmp3lame0
+      - libnuma1
+      - libopenjp2-7
+      - libopus0
       - libqt5multimedia5
       - libqt5multimedia5-plugins
       - libqt5qml5
-      - libelf1
-      - libepoxy0
-      - libzvbi0
-      - libzip4
-      - libxvidcore4
-      - libwebp6
-      - libwavpack1
-      - libvpx5
-      - libtwolame0
-      - libtheora0
-      - libssh-gcrypt-4
-      - libspeex1
-      - libsoxr0
-      - libsndio6.1
-      - libsnappy1v5
-      - libshine3
-      - libopus0
-      - libnuma1
-      - libmp3lame0
-      - libmodplug1
-      - libltdl7
-      - liblqr-1-0
-      - libgsm1
-      - libgomp1
-      - libgme0
-      - libfftw3-double3
-      - libcrystalhd3
-      - libxss1
+      - librtmp1
       - libsdl2-2.0-0
+      - libshine3
+      - libsnappy1v5
+      - libsndio6.1
+      - libsoxr0
+      - libspeex1
+      - libssh-gcrypt-4
+      - libswresample2
+      - libswscale4
+      - libtheora0
+      - libtwolame0
+      - libva2
+      - libvpx5
+      - libwavpack1
+      - libwebp6
       - libx264-152
       - libx265-146
-      - libva2
-      - libswscale4
-      - libswresample2
-      - libmagickwand-6.q16-3
-      - libopenjp2-7
-      - libbluray2
-      - libavutil55
-      - libavresample3
-      - libavformat57
-      - libavfilter6
-      - libmagickcore-6.q16-3
+      - libxss1
+      - libxvidcore4
+      - libzip4
+      - libzvbi0
       - qt5-style-plugins
       - qttranslations5-l10n
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -52,7 +52,7 @@ apps:
     plugs:
       - x11
       - home
-      - pulseaudio
+      - audio-playback
       - opengl
       - joystick
   mgba:
@@ -68,7 +68,7 @@ apps:
     plugs:
       - x11
       - home
-      - pulseaudio
+      - audio-playback
       - opengl
       - joystick
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -102,6 +102,7 @@ parts:
       - libavformat-dev
       - libavresample-dev
       - libavutil-dev
+      - libavfilter-dev
       - libminizip-dev
       - libpng-dev
       - libzip-dev
@@ -164,6 +165,7 @@ parts:
       - libavutil55
       - libavresample3
       - libavformat57
+      - libavfilter6
       - libmagickcore-6.q16-3
       - qt5-style-plugins
       - qttranslations5-l10n

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -96,6 +96,7 @@ parts:
     source: https://github.com/mgba-emu/mgba.git
     build-packages:
       - libedit-dev
+      - libelf-dev
       - libavcodec-dev
       - libavformat-dev
       - libavresample-dev
@@ -120,6 +121,7 @@ parts:
       - librtmp1
       - libqt5multimedia5
       - libqt5multimedia5-plugins
+      - libelf1
       - libepoxy0
       - libzvbi0
       - libzip4

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -137,6 +137,7 @@ parts:
       - libavresample3
       - libavformat57
       - libmagickcore-6.q16-3
+      - qt5-style-plugins
 
   desktop-qt5:
     build-packages:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -4,7 +4,7 @@ description: |
   mGBA is an emulator for running Game Boy Advance games. It aims to be faster
   and more accurate than many existing Game Boy Advance emulators, as well as
   adding features that other emulators lack. It also supports Game Boy and
-  Game Boy Color games..
+  Game Boy Color games.
 adopt-info: mgba
 base: core18
 


### PR DESCRIPTION
This PR adds some changes to the snapcraft.yaml file in order to enhance it's feature-set and improve the integration in GNOME/GTK environments. It also adds missing tools that are required for building the Qt translation files, so now the (custom) GUI translations are working.

### Before:
![mgba-before](https://user-images.githubusercontent.com/11882577/75624518-28cdb700-5bb5-11ea-8fd6-b107493c68a5.png)

### After:
![mgba-after](https://user-images.githubusercontent.com/11882577/75624519-2ff4c500-5bb5-11ea-8264-74ea59153462.png)

It also adds some libraries to allow using all the latest features.

### Known bugs (no regressions, since they were there before)
- "Default" Qt buttons are not translated and always in English
- Non-latin translations (e.g. Russian) are broken - bad UTF8 support?
- Networking functions like Discord RPC integration won't work even though the network plug is connected due to dbus accessiblity issues.