### PR TITLE
Fix version detection, add missing packages

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -89,10 +89,13 @@ parts:
         git fetch
         git checkout "${last_committed_tag}"
         cd ../src
-        git checkout "${last_committed_tag}"
+        snapcraftctl set-version "${last_committed_tag}"
+      else
+        git checkout master
+        snapcraftctl set-version "git"
       fi
       snapcraftctl build
-      snapcraftctl set-version "$(git describe --tags)"
+      
     configflags:
       - -DCMAKE_INSTALL_PREFIX:PATH=/usr
       - -DUPDATE_TRANSLATIONS=ON

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -99,6 +99,7 @@ parts:
     configflags:
       - -DCMAKE_INSTALL_PREFIX:PATH=/usr
       - -DUPDATE_TRANSLATIONS=ON
+      - -DUSE_DISCORD_RPC=OFF
     source: https://github.com/mgba-emu/mgba.git
     build-packages:
       - libavcodec-dev

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -205,3 +205,10 @@ parts:
     - locales-all
     - xdg-user-dirs
     - fcitx-frontend-qt5
+    - libatk1.0-0
+    - libgtk2.0-0
+    - libxcomposite1
+    - libxcursor1
+    - libxinerama1
+    - libxrandr2
+


### PR DESCRIPTION
This patch just fixes the version detection from the git repo and adds a bunch of missing stage-packages to the desktop-qt5 part. Additionally, disabling Discord RPC support since it currently crashes when launched from the snap.